### PR TITLE
Fix dashboard input datasource

### DIFF
--- a/demo/mib/dashboards/space_summary.json
+++ b/demo/mib/dashboards/space_summary.json
@@ -1,14 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_INFLUXDB",
-      "label": "InfluxDB",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "influxdb",
-      "pluginName": "InfluxDB"
-    }
-  ],
   "__requires": [
     {
       "type": "panel",
@@ -83,7 +73,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_INFLUXDB}",
+        "datasource": "InfluxDB",
         "hide": 0,
         "includeAll": false,
         "label": "Organization",
@@ -102,7 +92,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_INFLUXDB}",
+        "datasource": "InfluxDB",
         "hide": 0,
         "includeAll": false,
         "label": "Space",
@@ -121,7 +111,7 @@
       {
         "allValue": "*",
         "current": {},
-        "datasource": "${DS_INFLUXDB}",
+        "datasource": "InfluxDB",
         "hide": 0,
         "includeAll": true,
         "label": "Application",
@@ -254,7 +244,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "InfluxDB",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -406,7 +396,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "InfluxDB",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -564,7 +554,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "InfluxDB",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -717,7 +707,7 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "InfluxDB",
           "editable": true,
           "error": false,
           "format": "none",
@@ -832,7 +822,7 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "InfluxDB",
           "decimals": null,
           "editable": true,
           "error": false,
@@ -955,7 +945,7 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "InfluxDB",
           "editable": true,
           "error": false,
           "format": "none",
@@ -1077,7 +1067,7 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "InfluxDB",
           "editable": true,
           "error": false,
           "format": "none",
@@ -1199,7 +1189,7 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "InfluxDB",
           "editable": true,
           "error": false,
           "format": "none",
@@ -1323,7 +1313,7 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "InfluxDB",
           "editable": true,
           "error": false,
           "format": "none",
@@ -1453,7 +1443,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "InfluxDB",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -1598,7 +1588,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_INFLUXDB}",
+          "datasource": "InfluxDB",
           "decimals": 0,
           "editable": true,
           "error": false,


### PR DESCRIPTION
It seems that with my PR #18 I've break the summary dashboard and on a freshly provisioned mib it fails to find the datasource `DS_INFLUXDB `.

